### PR TITLE
added new placed note types, and art to the notes

### DIFF
--- a/scenes/ChartViewport/ChartManager.cs
+++ b/scenes/ChartViewport/ChartManager.cs
@@ -105,8 +105,8 @@ public partial class ChartManager : SubViewportContainer
         Color colorOverride = default
     )
     {
-        var newNote = CreateNote(type, beat); //TODO: Notes on track have unqiue visuals
-        var loopArrow = CreateNote(type, beat + BeatsPerLoop); //Create a dummy arrow for looping visuals
+        var newNote = CreateNote(type, note.Name, beat); //TODO: Notes on track have unqiue visuals
+        var loopArrow = CreateNote(type, note.Name, beat + BeatsPerLoop); //Create a dummy arrow for looping visuals
         if (colorOverride != default)
         {
             newNote.SelfModulate = colorOverride;
@@ -116,11 +116,11 @@ public partial class ChartManager : SubViewportContainer
         return newNote;
     }
 
-    private NoteArrow CreateNote(ArrowType arrow, int beat = 0)
+    private NoteArrow CreateNote(ArrowType arrow, string noteName, int beat = 0)
     {
         var noteScene = ResourceLoader.Load<PackedScene>("res://scenes/NoteManager/note.tscn");
         NoteArrow newArrow = noteScene.Instantiate<NoteArrow>();
-        newArrow.Init(IH.Arrows[(int)arrow], beat);
+        newArrow.Init(IH.Arrows[(int)arrow], beat, noteName);
         newArrow.OutlineSprite.Modulate = IH.Arrows[(int)arrow].Color;
 
         _arrowGroup.AddChild(newArrow);

--- a/scenes/NoteManager/note.tscn
+++ b/scenes/NoteManager/note.tscn
@@ -1,8 +1,13 @@
-[gd_scene load_steps=4 format=3 uid="uid://ck3bfqy30rjbq"]
+[gd_scene load_steps=9 format=3 uid="uid://ck3bfqy30rjbq"]
 
 [ext_resource type="Texture2D" uid="uid://hfxynr5jdgsp" path="res://scenes/NoteManager/assets/new_arrow.png" id="1_wq1hy"]
 [ext_resource type="Script" path="res://scenes/NoteManager/scripts/NoteArrow.cs" id="2_lbl4b"]
 [ext_resource type="Texture2D" uid="uid://cgq2ar3pdmkac" path="res://scenes/NoteManager/assets/arrow_outline.png" id="3_5g4ja"]
+[ext_resource type="Texture2D" uid="uid://c3chrsxrulapd" path="res://Classes/Notes/assets/single_note.png" id="4_1l7sl"]
+[ext_resource type="Texture2D" uid="uid://caw70lr5e1yiq" path="res://Classes/Notes/assets/double_note.png" id="5_yg3rb"]
+[ext_resource type="Texture2D" uid="uid://cdf3g3174du4r" path="res://Classes/Notes/assets/heal_note.png" id="6_lfb4v"]
+[ext_resource type="Texture2D" uid="uid://dg0lmu0pip4lr" path="res://Classes/Notes/assets/vampire_note.png" id="7_vcn70"]
+[ext_resource type="Texture2D" uid="uid://uksjoqp7p0gq" path="res://Classes/Notes/assets/quarter_note.png" id="8_2o4if"]
 
 [node name="Right-arrow" type="Sprite2D" node_paths=PackedStringArray("OutlineSprite")]
 texture = ExtResource("1_wq1hy")
@@ -11,3 +16,23 @@ OutlineSprite = NodePath("Outline")
 
 [node name="Outline" type="Sprite2D" parent="."]
 texture = ExtResource("3_5g4ja")
+
+[node name="PlayerBase" type="Sprite2D" parent="."]
+visible = false
+texture = ExtResource("4_1l7sl")
+
+[node name="PlayerDouble" type="Sprite2D" parent="."]
+visible = false
+texture = ExtResource("5_yg3rb")
+
+[node name="PlayerHeal" type="Sprite2D" parent="."]
+visible = false
+texture = ExtResource("6_lfb4v")
+
+[node name="PlayerVampire" type="Sprite2D" parent="."]
+visible = false
+texture = ExtResource("7_vcn70")
+
+[node name="PlayerQuarter" type="Sprite2D" parent="."]
+visible = false
+texture = ExtResource("8_2o4if")

--- a/scenes/NoteManager/scripts/NoteArrow.cs
+++ b/scenes/NoteManager/scripts/NoteArrow.cs
@@ -16,7 +16,7 @@ public partial class NoteArrow : Sprite2D
     [Export]
     public Sprite2D OutlineSprite;
 
-    public void Init(ArrowData parentArrowData, int beat)
+    public void Init(ArrowData parentArrowData, int beat, string noteName)
     {
         ZIndex = 1;
 
@@ -25,6 +25,15 @@ public partial class NoteArrow : Sprite2D
 
         Position += Vector2.Down * (parentArrowData.Node.GlobalPosition.Y);
         RotationDegrees = parentArrowData.Node.RotationDegrees;
+
+        if (noteName == "EnemyBase")
+            return;
+        Sprite2D child = GetNode<Sprite2D>(noteName);
+        if (child != null)
+        {
+            child.Visible = true;
+            child.RotationDegrees = -parentArrowData.Node.RotationDegrees;
+        }
     }
 
     public override void _Process(double delta)


### PR DESCRIPTION
Note queue now holds:
- 2x regular note
- 1x double note
- 1x heal note

Note queue now supports vampire notes, and quarter notes. Currently no way to access these notes, should be added as rewards.

Notes have the symbol from the note queue on top of their respective notes. Enemy notes have no symbol.