### PR TITLE
Fixed menu focusing bug

### DIFF
--- a/Scenes/UI/Remapping/ControlSettings.cs
+++ b/Scenes/UI/Remapping/ControlSettings.cs
@@ -151,6 +151,7 @@ public partial class ControlSettings : Node2D, IFocusableMenu
     {
         if (_remapPopup.Visible)
             _remapLabel.Text = ((int)_remapTimer.TimeLeft + 1).ToString();
+        NoNullFocus();
     }
 
     public void ResumeFocus()
@@ -175,6 +176,18 @@ public partial class ControlSettings : Node2D, IFocusableMenu
     {
         Prev.ResumeFocus();
         QueueFree();
+    }
+
+    private void NoNullFocus()
+    {
+        var focusedNode = GetViewport().GuiGetFocusOwner();
+        if (focusedNode != null)
+            return;
+        var defaultButton =
+            _remapTabs.CurrentTab == 0
+                ? GetNode<Control>(KeyboardTabPath + _inputNodeNames[0] + ButtonNameSuffix)
+                : GetNode<Control>(JoyTabPath + _inputNodeNames[0] + ButtonNameSuffix);
+        defaultButton.GrabFocus();
     }
 
     #endregion

--- a/Scenes/UI/Remapping/ControlSettings.cs
+++ b/Scenes/UI/Remapping/ControlSettings.cs
@@ -183,11 +183,7 @@ public partial class ControlSettings : Node2D, IFocusableMenu
         var focusedNode = GetViewport().GuiGetFocusOwner();
         if (focusedNode != null)
             return;
-        var defaultButton =
-            _remapTabs.CurrentTab == 0
-                ? GetNode<Control>(KeyboardTabPath + _inputNodeNames[0] + ButtonNameSuffix)
-                : GetNode<Control>(JoyTabPath + _inputNodeNames[0] + ButtonNameSuffix);
-        defaultButton.GrabFocus();
+        _remapTabs.GetTabBar().GrabFocus();
     }
 
     #endregion

--- a/Scenes/UI/Scripts/Inventory.cs
+++ b/Scenes/UI/Scripts/Inventory.cs
@@ -43,6 +43,11 @@ public partial class Inventory : Control, IFocusableMenu
         }
     }
 
+    public override void _Process(double delta)
+    {
+        NoNullFocus();
+    }
+
     public override void _Input(InputEvent @event)
     {
         if (!GetWindow().HasFocus())
@@ -99,6 +104,20 @@ public partial class Inventory : Control, IFocusableMenu
     {
         Prev.ResumeFocus();
         QueueFree();
+    }
+
+    private void NoNullFocus()
+    {
+        var focusedNode = GetViewport().GuiGetFocusOwner();
+        if (focusedNode != null)
+            return;
+
+        Node parentNode = _tabs.CurrentTab == 0 ? _notes : _relics;
+        if (parentNode.GetChildCount() <= 0)
+            return;
+
+        var defaultButton = parentNode.GetChild(0) as Control;
+        defaultButton?.GrabFocus();
     }
 
     private void DoDescription(DisplayButton dispButton)

--- a/Scenes/UI/Scripts/Inventory.cs
+++ b/Scenes/UI/Scripts/Inventory.cs
@@ -111,13 +111,8 @@ public partial class Inventory : Control, IFocusableMenu
         var focusedNode = GetViewport().GuiGetFocusOwner();
         if (focusedNode != null)
             return;
-
-        Node parentNode = _tabs.CurrentTab == 0 ? _notes : _relics;
-        if (parentNode.GetChildCount() <= 0)
-            return;
-
-        var defaultButton = parentNode.GetChild(0) as Control;
-        defaultButton?.GrabFocus();
+        _tabs.GetTabBar().GrabFocus();
+        ClearDescription(-1);
     }
 
     private void DoDescription(DisplayButton dispButton)


### PR DESCRIPTION
This fixes the bug where a user presses down and left or right at the same time with the tab containers in the game. Unless there is another tab container other than the remap controls menu or the inventory screen, #163 should be marked as completed.